### PR TITLE
Edited setup.py to prevent 'error in setup command' on Windows paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
     install_requires=["cffi>=1.0.0"],
     setup_requires=["cffi>=1.0.0"],
     cffi_modules=[
-        os.path.join(here, "build.py:ffi")
+        os.path.join(path.dirname(__file__), "build.py:ffi")
     ],
     test_suite='tests',
 


### PR DESCRIPTION
When trying to install from source on Windows, the following error occurs:

> error in torchwordemb setup command: 'C:\\Code\\pytorch-wordemb\\build.py:ffi' must be of the form 'path/build.py:ffi_variable'

Changing to relative path here prevents this error.